### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+fastapi


### PR DESCRIPTION
FastAPI needs to be installed from pip first. Adding requirements.txt to make it obvious.